### PR TITLE
Meta Tags and Categories

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -415,12 +415,52 @@ if ( ! function_exists( 'garfunkel_meta' ) ) :
 				<span class="meta-text"><?php the_time( get_option( 'date_format' ) ); ?></span>
 			</a>
 
-			<?php if ( comments_open() ) : ?>
-				<a class="post-meta-comments" href="<?php the_permalink(); ?>#comments">
-					<div class="genericon genericon-comment"></div>
-					<span class="meta-text"><?php comments_number( '0', '1', '%' ); ?></span>
-				</a>
-			<?php endif; ?>
+		<?php if( get_theme_mod( 'garfunkel_show_categories' ) ) : ?>
+			<a class="post-meta-categories" href="<?php the_permalink(); ?>">
+			<?php
+				$categories = get_the_category();
+			    $separator = ', ';
+			    $output = '';
+			    if( is_array( $categories ) && count( $categories ) > 0 ) {
+					echo '				<div class="genericon genericon-category"></div>' . PHP_EOL;
+					echo '				<span class="meta-text">' . PHP_EOL;
+
+			        foreach ( $categories as $category ) {
+			            $output .= esc_html( $category->name ) . $separator;
+			        }
+
+		        	echo trim( $output, $separator );
+			    }
+				?></span>
+			</a>
+		<?php endif; ?>
+
+		<?php if( get_theme_mod( 'garfunkel_show_tags' ) ) : ?>
+			<a class="post-meta-tags" href="<?php the_permalink(); ?>">
+			<?php
+				$tags = get_the_tags();
+			    $separator = ', ';
+			    $output = '';
+			    if( is_array( $tags ) && count( $tags ) > 0 ) {
+					echo '				<div class="genericon genericon-tag"></div>' . PHP_EOL;
+					echo '				<span class="meta-text">' . PHP_EOL;
+
+			        foreach ( $tags as $tag ) {
+			            $output .= esc_html( $tag->name ) . $separator;
+			        }
+
+			        echo trim( $output, $separator );
+			    }
+				?></span>
+			</a>
+		<?php endif; ?>
+
+		<?php if ( comments_open() ) : ?>
+			<a class="post-meta-comments" href="<?php the_permalink(); ?>#comments">
+				<div class="genericon genericon-comment"></div>
+				<span class="meta-text"><?php comments_number( '0', '1', '%' ); ?></span>
+			</a>
+		<?php endif; ?>
 
 		</div><!-- .post-meta -->
 		

--- a/inc/classes/class-garfunkel-customize.php
+++ b/inc/classes/class-garfunkel-customize.php
@@ -4,25 +4,25 @@
    CUSTOMIZER SETTINGS
    --------------------------------------------------------------------------------------------- */
 
-if ( ! class_exists( 'Garfunkel_Customize' ) ) : 
+if ( ! class_exists( 'Garfunkel_Customize' ) ) :
 	class Garfunkel_Customize {
 
 		public static function register( $wp_customize ) {
 
 			/* Accent Color ------------------ */
-			
+
 			$wp_customize->add_setting( 'accent_color', array(
-				'default' 			=> '#ca2017', 
-				'type' 				=> 'theme_mod', 
-				'capability' 		=> 'edit_theme_options', 
+				'default' 			=> '#ca2017',
+				'type' 				=> 'theme_mod',
+				'capability' 		=> 'edit_theme_options',
 				'sanitize_callback' => 'sanitize_hex_color'
 			) );
-			
+
 			$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'garfunkel_accent_color', array(
-				'label' 	=> __( 'Accent Color', 'garfunkel' ), 
-				'section' 	=> 'colors', 
-				'settings' 	=> 'accent_color', 
-				'priority' 	=> 10, 
+				'label' 	=> __( 'Accent Color', 'garfunkel' ),
+				'section' 	=> 'colors',
+				'settings' 	=> 'accent_color',
+				'priority' 	=> 10,
 			) ) );
 
 			/* Custom Logo ------------------- */
@@ -37,8 +37,8 @@ if ( ! class_exists( 'Garfunkel_Customize' ) ) :
 					'priority'    => 40,
 					'description' => 'Upload a logo to replace the default site name and description in the header',
 				) );
-				
-				$wp_customize->add_setting( 'garfunkel_logo', array( 
+
+				$wp_customize->add_setting( 'garfunkel_logo', array(
 					'sanitize_callback' => 'esc_url_raw'
 				) );
 
@@ -52,47 +52,47 @@ if ( ! class_exists( 'Garfunkel_Customize' ) ) :
 
 			/* Garfunkel Section ------------- */
 
-            $wp_customize->add_section(
-                'garfunkel_options', array(
-                'title' => __('Garfunkel', 'garfunkel'),
-                'description' => '',
-                'priority' => 120,
-                )
-            );
+			$wp_customize->add_section(
+			    'garfunkel_options', array(
+			    'title' => __('Garfunkel', 'garfunkel'),
+			    'description' => '',
+			    'priority' => 120,
+			    )
+			);
 
 			/* Show Categories in Meta ------- */
 
-            $wp_customize->add_setting(
-                'garfunkel_show_categories', array(
-                'default' => ''
-                )
-            );
+			$wp_customize->add_setting(
+			    'garfunkel_show_categories', array(
+			    'default' => ''
+			    )
+			);
 
-            $wp_customize->add_control(
-                'garfunkel_show_categories', array(
-                'label' => 'Show categories on archive pages.',
-                'type'  => 'checkbox',
-                'section' => 'garfunkel_options',
-                'settings' => 'garfunkel_show_categories'
-                )
-            );
+			$wp_customize->add_control(
+			    'garfunkel_show_categories', array(
+			    'label' => 'Show categories on archive pages.',
+			    'type'  => 'checkbox',
+			    'section' => 'garfunkel_options',
+			    'settings' => 'garfunkel_show_categories'
+			    )
+			);
 
 			/* Show Tags in Meta ------------- */
 
-            $wp_customize->add_setting(
-                'garfunkel_show_tags', array(
-                'default' => ''
-                )
-            );
+			$wp_customize->add_setting(
+			    'garfunkel_show_tags', array(
+			    'default' => ''
+			    )
+			);
 
-            $wp_customize->add_control(
-                'garfunkel_show_tags', array(
-                'label' => 'Show tags on archive pages.',
-                'type'  => 'checkbox',
-                'section' => 'garfunkel_options',
-                'settings' => 'garfunkel_show_tags'
-                )
-            );
+			$wp_customize->add_control(
+			    'garfunkel_show_tags', array(
+			    'label' => 'Show tags on archive pages.',
+			    'type'  => 'checkbox',
+			    'section' => 'garfunkel_options',
+			    'settings' => 'garfunkel_show_tags'
+			    )
+			);
         }
 
 		public static function header_output() {
@@ -102,7 +102,7 @@ if ( ! class_exists( 'Garfunkel_Customize' ) ) :
 
 			// Only output Custom CSS if it differs from the default
 			if ( $accent == $accent_default ) return;
-		
+
 			echo '<!--Customizer CSS-->';
 			echo '<style type="text/css">';
 
@@ -174,7 +174,7 @@ if ( ! class_exists( 'Garfunkel_Customize' ) ) :
 
 			echo '</style>';
 			echo '<!--/Customizer CSS-->';
-			
+
 		}
 
 		public static function generate_css( $selector, $style, $value, $prefix = '', $postfix = '', $echo = true ) {

--- a/inc/classes/class-garfunkel-customize.php
+++ b/inc/classes/class-garfunkel-customize.php
@@ -50,7 +50,50 @@ if ( ! class_exists( 'Garfunkel_Customize' ) ) :
 
 			}
 
-		}
+			/* Garfunkel Section ------------- */
+
+            $wp_customize->add_section(
+                'garfunkel_options', array(
+                'title' => __('Garfunkel', 'garfunkel'),
+                'description' => '',
+                'priority' => 120,
+                )
+            );
+
+			/* Show Categories in Meta ------- */
+
+            $wp_customize->add_setting(
+                'garfunkel_show_categories', array(
+                'default' => ''
+                )
+            );
+
+            $wp_customize->add_control(
+                'garfunkel_show_categories', array(
+                'label' => 'Show categories on archive pages.',
+                'type'  => 'checkbox',
+                'section' => 'garfunkel_options',
+                'settings' => 'garfunkel_show_categories'
+                )
+            );
+
+			/* Show Tags in Meta ------------- */
+
+            $wp_customize->add_setting(
+                'garfunkel_show_tags', array(
+                'default' => ''
+                )
+            );
+
+            $wp_customize->add_control(
+                'garfunkel_show_tags', array(
+                'label' => 'Show tags on archive pages.',
+                'type'  => 'checkbox',
+                'section' => 'garfunkel_options',
+                'settings' => 'garfunkel_show_tags'
+                )
+            );
+        }
 
 		public static function header_output() {
 


### PR DESCRIPTION
The main/archive pages include the post date and comment count for each post, however categories and tags and not shown.

This PR adds these as options so that the post info can look like this:
![Screenshot from 2023-01-15 12-32-31](https://user-images.githubusercontent.com/9053749/212557090-e0a96ade-2f24-4dd1-aebd-d2912eae12e3.png)

A new customizer section has been added called "Garfunkel" to house these settings:
![Screenshot from 2023-01-15 12-33-35](https://user-images.githubusercontent.com/9053749/212557149-0491155e-452f-4b8b-aa09-cfdc0f05acaf.png)
